### PR TITLE
Support for running builds using docker compose

### DIFF
--- a/lib/build_config.rb
+++ b/lib/build_config.rb
@@ -11,7 +11,12 @@ class BuildConfig
   end
 
   def docker_image
-    @config['docker_image'] || DEFAULT_DOCKER_IMAGE
+    default_image = docker_compose.nil? ? DEFAULT_DOCKER_IMAGE : nil
+    @config['docker_image'] || default_image
+  end
+
+  def docker_compose
+    @config['docker_compose']
   end
 
   def header

--- a/spec/fixtures/docker_compose_app_config.yml
+++ b/spec/fixtures/docker_compose_app_config.yml
@@ -1,0 +1,11 @@
+web:
+  build: .
+  ports:
+   - "5000:5000"
+  volumes:
+   - .:/code
+  links:
+   - redis
+  command: "rake"
+redis:
+  image: redis

--- a/spec/fixtures/docker_compose_app_config_no_volumes.yml
+++ b/spec/fixtures/docker_compose_app_config_no_volumes.yml
@@ -1,0 +1,8 @@
+web:
+  build: .
+  ports:
+   - "5000:5000"
+  links:
+   - redis
+redis:
+  image: redis

--- a/spec/fixtures/docker_compose_build_config.yml
+++ b/spec/fixtures/docker_compose_build_config.yml
@@ -1,0 +1,16 @@
+docker_compose:
+  config: 'docker-compose-ci.yml'
+  app_container_name: web
+test:
+- rake
+- "mvn test"
+deploy:
+  some_deployment_target:
+    branch: master
+    cmds:
+      - asdf
+      - bar
+  some_other_target:
+    branch: release
+    cmds:
+      - fubar

--- a/spec/lib/build_config_spec.rb
+++ b/spec/lib/build_config_spec.rb
@@ -86,12 +86,39 @@ describe BuildConfig do
   end
 
   describe "#docker_image" do
-    it "returns docker image specified" do
-      expect(build_config.docker_image).to eq('ubuntu:15.10')
+    context "docker image config" do
+      it "returns docker image specified" do
+        expect(build_config.docker_image).to eq('ubuntu:15.10')
+      end
+
+      it "uses the default docker image if not specified" do
+        expect(empty_build_config.docker_image).to eq('ubuntu:14.04')
+      end
     end
 
-    it "uses the default docker image if not specified" do
-      expect(empty_build_config.docker_image).to eq('ubuntu:14.04')
+    context "docker compose config" do
+      let(:build_config_fixture) { File.read('spec/fixtures/docker_compose_build_config.yml') }
+
+      it "returns nil" do
+        expect(build_config.docker_image).to be_nil
+      end
+    end
+  end
+
+  describe "#docker_compose" do
+    context "docker image config" do
+      it "returns docker compose configuration settings" do
+        expect(build_config.docker_compose).to be_nil
+      end
+    end
+
+    context "docker compose config" do
+      let(:build_config_fixture) { File.read('spec/fixtures/docker_compose_build_config.yml') }
+
+      it "returns docker compose configuration settings" do
+        expect(build_config.docker_compose['config']).to eq('docker-compose-ci.yml')
+        expect(build_config.docker_compose['app_container_name']).to eq('web')
+      end
     end
   end
 


### PR DESCRIPTION
This adds support for specifying a docker compose configuration rather than a single docker image to run builds in. I might have totally missed the point on this one, but wanted your thoughts.
